### PR TITLE
Update MORK api calls and centeralize them in `mork_api.rs`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Cargo.lock
 .idea
 
 .env
+.env*
 
 temp/
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -15,7 +15,11 @@ uuid = { version = "1.10.0", features = ["v4"] }
 rocket_cors = "0.6.0"
 chrono = { version = "0.4.38", features = ["serde"] }
 regex = "1.10.6"
-reqwest = "0.12.15"
+reqwest = { version = "0.12.15", features = ["json"] }
 urlencoding = "2.1.3"
 openssl = { version = "0.10.72", features = ["vendored"] }
 pq-sys = { version = "0.6", features = ["bundled"] }
+
+[dev-dependencies]
+httpmock = "0.7.0"
+tokio = { version = "1.38.0", features = ["full"] }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -6,12 +6,16 @@ use rocket_cors::AllowedOrigins;
 mod db;
 mod model;
 mod routes;
+mod mork_api;
 mod schema;
 
 #[launch]
 fn rocket() -> Rocket<Build> {
     // TODO: move hardcoded allowed origins to database,
     // or get backend and frontend hosted under same domain
+    
+    dotenv::dotenv().ok();
+    
     let allowed_origins =
         AllowedOrigins::some_exact(&["http://localhost:3000", "https://metta-kg.vercel.app"]);
 

--- a/api/src/mork_api.rs
+++ b/api/src/mork_api.rs
@@ -287,7 +287,8 @@ impl Request for ReadRequest {
 
     fn path(&self) -> String {
         format!(
-            "/export/{}/{}/",
+            "/export/({0} ({1}))/({0} ({2}))/",
+            self.transform_input.space.to_str().unwrap_or("/"),
             self.transform_input
                 .patterns
                 .first()

--- a/api/src/mork_api.rs
+++ b/api/src/mork_api.rs
@@ -1,0 +1,317 @@
+use reqwest::{Client, Method};
+use rocket::http::Status;
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::path::PathBuf;
+
+#[derive(Serialize, Deserialize, Clone)]
+#[allow(dead_code)]
+pub enum ExportFormat {
+    Metta,
+    Json,
+    Csv,
+    Raw,
+}
+
+pub trait TransformSetter: Sized {
+    fn transform_input_mut(&mut self) -> &mut TransformInput;
+
+    fn pattern(mut self, pattern: impl Into<String>) -> Self {
+        self.transform_input_mut().pattern = pattern.into();
+        self
+    }
+
+    fn template(mut self, template: impl Into<String>) -> Self {
+        self.transform_input_mut().template = template.into();
+        self
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct TransformInput {
+    pub pattern: String,
+    pub template: String,
+}
+
+impl Default for TransformInput {
+    fn default() -> Self {
+        TransformInput {
+            pattern: String::from("$x"),
+            template: String::from("$x"),
+        }
+    }
+}
+
+#[allow(dead_code)]
+impl TransformInput {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn pattern(mut self, pattern: String) -> Self {
+        self.pattern = pattern;
+        self
+    }
+
+    pub fn template(mut self, template: String) -> Self {
+        self.template = template;
+        self
+    }
+
+    pub fn generate_code(&self) -> String {
+        format!("transform(,{0})(,{1})", self.pattern, self.template)
+    }
+}
+
+pub struct MorkApiClient {
+    base_url: String,
+    client: Client,
+}
+
+impl MorkApiClient {
+    pub fn new() -> Self {
+        let mork_url = env::var("METTA_KG_MORK_URL").expect("METTA_KG_MORK_URL must be set");
+        Self {
+            base_url: mork_url,
+            client: Client::new(),
+        }
+    }
+
+    pub async fn dispatch<R: Request>(&self, request: R) -> Result<String, Status> {
+        let url = format!("{}{}", self.base_url, request.path());
+        let mut http_request = self.client.request(request.method(), &url);
+
+        if let Some(body) = request.body() {
+            http_request = http_request.json(&body);
+        }
+
+        match http_request.send().await {
+            Ok(resp) => match resp.text().await {
+                Ok(text) => Ok(text),
+                Err(e) => {
+                    eprintln!("Error reading Mork API response text: {}", e);
+                    Err(Status::InternalServerError)
+                }
+            },
+            Err(e) => {
+                eprintln!("Error sending request to Mork API: {}", e);
+                Err(Status::InternalServerError)
+            }
+        }
+    }
+}
+
+pub trait Request {
+    type Body: Serialize;
+    fn method(&self) -> Method;
+    fn path(&self) -> String;
+    fn body(&self) -> Option<Self::Body> {
+        None
+    }
+}
+
+#[derive(Serialize, Deserialize, Clone)]
+pub struct TransformRequest {
+    input_space: PathBuf,
+    output_space: PathBuf,
+    transform_input: TransformInput,
+}
+
+impl Default for TransformRequest {
+    fn default() -> Self {
+        TransformRequest {
+            input_space: PathBuf::from("/"),
+            output_space: PathBuf::from("/"),
+            transform_input: TransformInput::default(),
+        }
+    }
+}
+
+impl TransformRequest {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn input_space(mut self, input_space: PathBuf) -> Self {
+        self.input_space = input_space;
+        self
+    }
+
+    pub fn output_space(mut self, output_space: PathBuf) -> Self {
+        self.output_space = output_space;
+        self
+    }
+}
+
+impl TransformSetter for TransformRequest {
+    fn transform_input_mut(&mut self) -> &mut TransformInput {
+        &mut self.transform_input
+    }
+}
+
+impl Request for TransformRequest {
+    type Body = ();
+
+    fn method(&self) -> Method {
+        Method::POST
+    }
+
+    fn path(&self) -> String {
+        format!("/transform/{}/", self.transform_input.generate_code())
+    }
+}
+
+pub struct ImportRequest {
+    transform_input: TransformInput,
+    uri: String,
+}
+
+impl Default for ImportRequest {
+    fn default() -> Self {
+        ImportRequest {
+            transform_input: TransformInput::default(),
+            uri: String::from(""),
+        }
+    }
+}
+
+impl ImportRequest {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn uri(mut self, uri: String) -> Self {
+        self.uri = uri;
+        self
+    }
+}
+
+impl TransformSetter for ImportRequest {
+    fn transform_input_mut(&mut self) -> &mut TransformInput {
+        &mut self.transform_input
+    }
+}
+
+impl Request for ImportRequest {
+    type Body = ();
+
+    fn method(&self) -> Method {
+        Method::POST
+    }
+
+    fn path(&self) -> String {
+        format!(
+            "/import/{}/{}?uri={}",
+            self.transform_input.pattern, self.transform_input.template, self.uri
+        )
+    }
+}
+
+#[derive(Default)]
+#[allow(dead_code)]
+pub struct ReadRequest {
+    transform_input: TransformInput,
+    export_url: Option<String>,
+    format: Option<ExportFormat>,
+}
+
+impl ReadRequest {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
+impl TransformSetter for ReadRequest {
+    fn transform_input_mut(&mut self) -> &mut TransformInput {
+        &mut self.transform_input
+    }
+}
+
+impl Request for ReadRequest {
+    type Body = ();
+
+    fn method(&self) -> Method {
+        Method::GET
+    }
+
+    fn path(&self) -> String {
+        format!(
+            "/export/{}/{}",
+            self.transform_input.pattern, self.transform_input.template
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::prelude::*;
+
+    #[tokio::test]
+    async fn test_transform_request() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST).path("/transform/transform(,$x)(,$x)/");
+            then.status(200).body("transform success");
+        });
+
+        let client = MorkApiClient {
+            base_url: server.base_url(),
+            client: Client::new(),
+        };
+
+        let request = TransformRequest::new();
+
+        let result = client.dispatch(request).await.unwrap();
+
+        mock.assert();
+        assert_eq!(result, "transform success");
+    }
+
+    #[tokio::test]
+    async fn test_import_request() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/import/$x/$x")
+                .query_param("uri", "http://example.com");
+            then.status(200).body("import success");
+        });
+
+        let client = MorkApiClient {
+            base_url: server.base_url(),
+            client: Client::new(),
+        };
+
+        let request = ImportRequest::new().uri("http://example.com".to_string());
+
+        let result = client.dispatch(request).await.unwrap();
+
+        mock.assert();
+        assert_eq!(result, "import success");
+    }
+
+    #[tokio::test]
+    async fn test_read_request() {
+        let server = MockServer::start();
+
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/export/$x/$x");
+            then.status(200).body("read success");
+        });
+
+        let client = MorkApiClient {
+            base_url: server.base_url(),
+            client: Client::new(),
+        };
+
+        let request = ReadRequest::new();
+
+        let result = client.dispatch(request).await.unwrap();
+
+        mock.assert();
+        assert_eq!(result, "read success");
+    }
+}

--- a/api/src/mork_api.rs
+++ b/api/src/mork_api.rs
@@ -134,6 +134,7 @@ impl MorkApiClient {
             http_request = http_request.json(&body);
         }
 
+        http_request = http_request.timeout(request.timeout());
         match http_request.send().await {
             Ok(resp) => match resp.text().await {
                 Ok(text) => Ok(text),
@@ -156,6 +157,9 @@ pub trait Request {
     fn path(&self) -> String;
     fn body(&self) -> Option<Self::Body> {
         None
+    }
+    fn timeout(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(20)
     }
 }
 
@@ -297,7 +301,6 @@ impl Request for ReadRequest {
                 .templates
                 .first()
                 .unwrap_or(&String::from("&x")),
-
         )
     }
 }

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -1,28 +1,22 @@
-use chrono::format;
-use core::str;
-use diesel::{ExpressionMethods, RunQueryDsl};
 use rocket::http::Status;
 use rocket::serde::json::Json;
 use serde::{Deserialize, Serialize};
-use std::cmp::Ordering;
-use std::collections::HashSet;
-use std::env;
 use std::fs::File;
 use std::io::prelude::*;
 use uuid::Uuid;
 
 use rocket::{get, post};
 use std::path::PathBuf;
-use urlencoding::encode;
 
-use crate::{db::establish_connection, model::Token};
+use crate::mork_api::{ImportRequest, MorkApiClient, ReadRequest, TransformRequest, TransformSetter};
+use crate::model::Token;
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Default, Serialize, Deserialize, Clone)]
 pub struct Transformation {
-    input_space: PathBuf,
-    output_space: PathBuf,
-    pattern: String,
-    template: String,
+    pub input_space: PathBuf,
+    pub output_space: PathBuf,
+    pub pattern: String,
+    pub template: String,
 }
 
 #[post("/spaces", data = "<transformation>")]
@@ -32,156 +26,65 @@ pub async fn transform(
 ) -> Result<Json<bool>, Status> {
     let token_namespace = token.namespace.strip_prefix("/").unwrap();
 
-    let input_space_path = transformation.input_space.clone();
-    let output_space_path = transformation.output_space.clone();
-    let pattern = transformation.pattern.clone();
-    let template = transformation.template.clone();
-
-    if !input_space_path.starts_with(&token_namespace)
-        || !output_space_path.starts_with(&token_namespace)
+    if !transformation.input_space.starts_with(token_namespace)
+        || !transformation.output_space.starts_with(token_namespace)
         || !token.permission_read
         || !token.permission_write
     {
         return Err(Status::Unauthorized);
     }
 
-    let input_path_serialized = input_space_path.into_os_string().into_string().unwrap();
+    let mork_api_client = MorkApiClient::new();
+    let request = TransformRequest::new()
+        .input_space(transformation.input_space.to_path_buf())
+        .output_space(transformation.output_space.to_path_buf())
+        .pattern(transformation.pattern.clone())
+        .template(transformation.template.clone());
 
-    let output_path_serialized = output_space_path.into_os_string().into_string().unwrap();
-
-    let mork_url = env::var("METTA_KG_MORK_URL").unwrap();
-
-    let mork_transform_url = format!(
-        "{}/transform/{}/{}/{}/{}",
-        mork_url,
-        encode(&input_path_serialized),
-        encode(&output_path_serialized),
-        encode(&pattern),
-        encode(&template)
-    );
-
-    let resp = reqwest::get(mork_transform_url).await;
-
-    let data = match resp {
-        Ok(resp) => resp.text().await,
-        Err(e) => {
-            eprintln!("Error sending MORK transform request: {}", e);
-            return Err(Status::InternalServerError);
-        }
-    };
-
-    match data {
-        Ok(data) => {
-            println!("MORK transform request response text: {}", data);
-            Ok(Json(true))
-        }
-        Err(e) => {
-            eprintln!(
-                "Error converting MORK transform request response to textual string: {}",
-                e
-            );
-            return Err(Status::InternalServerError);
-        }
+    match mork_api_client.dispatch(request).await {
+        Ok(_) => Ok(Json(true)),
+        Err(e) => Err(e),
     }
 }
 
 #[post("/spaces/<path..>", data = "<space>")]
 pub async fn import(token: Token, path: PathBuf, space: String) -> Result<Json<bool>, Status> {
-    if !path.starts_with(&token.namespace.strip_prefix("/").unwrap()) || !token.permission_write {
+    if !path.starts_with(token.namespace.strip_prefix("/").unwrap()) || !token.permission_write {
         return Err(Status::Unauthorized);
     }
 
     let file_id = Uuid::new_v4();
     let file_path = format!("static/{}.metta", file_id);
 
-    let file = File::create(&file_path);
-
-    let write_result = match file {
-        Ok(mut a) => a.write_all(space.as_bytes()),
-        Err(e) => {
-            eprintln!("Error saving file for MORK import request: {}", e);
+    if let Ok(mut file) = File::create(&file_path) {
+        if file.write_all(space.as_bytes()).is_err() {
             return Err(Status::InternalServerError);
         }
-    };
-
-    match write_result {
-        Ok(_) => println!("Successfully wrote MeTTa string to file {}", &file_path),
-        Err(e) => {
-            eprintln!("Error writing to file for MORK import request: {}", e);
-            return Err(Status::InternalServerError);
-        }
+    } else {
+        return Err(Status::InternalServerError);
     }
 
-    let path_serialized = path.into_os_string().into_string().unwrap();
+    let _path_serialized = path.to_str().unwrap_or_default();
+    let import_file_url = format!("/public/{}.metta", file_id);
 
-    let mork_url = env::var("METTA_KG_MORK_URL").unwrap();
-    let origin = env::var("METTA_KG_ORIGIN_URL").unwrap();
+    let mork_api_client = MorkApiClient::new();
+    let request = ImportRequest::new()
+        .uri(import_file_url);
 
-    let import_file_url = format!("{}/public/{}.metta", origin, file_id);
-
-    let mork_import_url = format!(
-        "{}/import/{}?uri={}",
-        mork_url, path_serialized, import_file_url
-    );
-
-    let resp = reqwest::get(mork_import_url).await;
-
-    let data = match resp {
-        Ok(resp) => resp.text().await,
-        Err(e) => {
-            eprintln!("Error sending MORK import request: {}", e);
-            return Err(Status::InternalServerError);
-        }
-    };
-
-    match data {
-        Ok(data) => {
-            println!("MORK import request response text: {}", data);
-            Ok(Json(true))
-        }
-        Err(e) => {
-            eprintln!(
-                "Error converting MORK import request response to textual string: {}",
-                e
-            );
-            return Err(Status::InternalServerError);
-        }
+    match mork_api_client.dispatch(request).await {
+        Ok(_) => Ok(Json(true)),
+        Err(e) => Err(e),
     }
 }
 
 #[get("/spaces/<path..>")]
 pub async fn read(token: Token, path: PathBuf) -> Result<Json<String>, Status> {
-    if !path.starts_with(&token.namespace.strip_prefix("/").unwrap()) || !token.permission_read {
+    if !path.starts_with(token.namespace.strip_prefix("/").unwrap()) || !token.permission_read {
         return Err(Status::Unauthorized);
     }
 
-    let path_serialized = path.into_os_string().into_string().unwrap();
+    let mork_api_client = MorkApiClient::new();
+    let request = ReadRequest::new();
 
-    let mork_url = env::var("METTA_KG_MORK_URL").unwrap();
-
-    let mork_export_url = format!("{}/export/{}", mork_url, path_serialized);
-
-    let resp = reqwest::get(mork_export_url).await;
-
-    let data = match resp {
-        Ok(resp) => resp.text().await,
-        Err(e) => {
-            eprintln!("Error sending MORK export request: {}", e);
-            return Err(Status::InternalServerError);
-        }
-    };
-
-    match data {
-        Ok(data) => {
-            println!("MORK export request response text: {}", data);
-            Ok(Json(data))
-        }
-        Err(e) => {
-            eprintln!(
-                "Error converting MORK export request response to textual string: {}",
-                e
-            );
-            return Err(Status::InternalServerError);
-        }
-    }
+    mork_api_client.dispatch(request).await.map(Json)
 }

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -61,7 +61,6 @@ pub async fn import(token: Token, path: PathBuf, space_data: String) -> Result<J
         return Err(Status::InternalServerError);
     }
 
-    let _path_serialized = path.to_str().unwrap_or_default();
     let import_file_url = format!("/public/{}.metta", file_id);
 
     let mork_api_client = MorkApiClient::new();

--- a/api/src/routes/translations.rs
+++ b/api/src/routes/translations.rs
@@ -22,21 +22,18 @@ pub struct CSVParserParameters {
 }
 
 #[derive(FromForm, Clone)]
-#[allow(dead_code)]
 pub struct NTParserParameters {
     // TODO: figure out how to deal with this normally empty struct
     pub dummy: String,
 }
 
 #[derive(FromForm, Clone)]
-#[allow(dead_code)]
 pub struct N3ParserParameters {
     // TODO: figure out how to deal with this normally empty struct
     pub dummy: String,
 }
 
 #[derive(FromForm, Clone)]
-#[allow(dead_code)]
 pub struct JSONLDParserParameters {
     // TODO: figure out how to deal with this normally empty struct
     pub dummy: String,

--- a/api/src/routes/translations.rs
+++ b/api/src/routes/translations.rs
@@ -22,18 +22,21 @@ pub struct CSVParserParameters {
 }
 
 #[derive(FromForm, Clone)]
+#[allow(dead_code)]
 pub struct NTParserParameters {
     // TODO: figure out how to deal with this normally empty struct
     pub dummy: String,
 }
 
 #[derive(FromForm, Clone)]
+#[allow(dead_code)]
 pub struct N3ParserParameters {
     // TODO: figure out how to deal with this normally empty struct
     pub dummy: String,
 }
 
 #[derive(FromForm, Clone)]
+#[allow(dead_code)]
 pub struct JSONLDParserParameters {
     // TODO: figure out how to deal with this normally empty struct
     pub dummy: String,


### PR DESCRIPTION
### Summary

This PR refactors the MORK API integration to improve code organization, reusability, and testability.

### What's Changed
- Updated MORK api calls to current implementations of MORK
- Introduced `mork_api.rs` with centralized client, request builders, and shared traits.
- Replaced direct `reqwest` usage in `spaces.rs` with `MorkApiClient`.
- Added `.env*` to `.gitignore` for flexible environment management.
- Updated `reqwest` dependency to include `json` feature.
- Added `httpmock` and `tokio` (full) as dev dependencies for async testing.
- Enabled dotenv loading in `main.rs`.
- Minor cleanups in unused parser parameter structs in `translations.rs`.

### Benefits
- Fix bugs related to legacy mork api
- Simplifies API request handling.
- Enables easier mocking and unit testing.
- Reduces repetition and potential bugs in route handlers.

### Test Coverage
- Unit tests included in `mork_api.rs` (additional async tests scaffolded).
