### PR TITLE
Fix/token error management

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -43,6 +43,9 @@ export async function request<T>(
   const response = await fetch(finalUrl, { ...options, headers });
 
   if (!response.ok) {
+    if (response.status === 401 || response.status === 403) {
+      throw new Error("Unauthorized");
+    }
     const contentType = response.headers.get("content-type");
     if (contentType && contentType.includes("application/json")) {
       const errorData = await response.json();

--- a/frontend/src/pages/tokens/Tokens.tsx
+++ b/frontend/src/pages/tokens/Tokens.tsx
@@ -52,6 +52,10 @@ export const TokensPage: Component = () => {
       return currentNs === trimTrailingSlash(tokenNs);
     });
   };
+
+  const shouldShowContent = () =>
+    rootToken() && !tokens.loading && tokens().length > 0;
+
   return (
     <div class="ml-10 mt-8 space-y-8">
       <CommandCard
@@ -61,7 +65,7 @@ export const TokensPage: Component = () => {
         <RootTokenForm initialToken={rootToken()} onLoad={setRootToken} />
       </CommandCard>
 
-      <Show when={rootToken()}>
+      <Show when={shouldShowContent()}>
         <CommandCard
           title="Create New Token"
           description="Define a namespace, description, and permissions for a new token."

--- a/frontend/src/pages/tokens/components/RootTokenForm.tsx
+++ b/frontend/src/pages/tokens/components/RootTokenForm.tsx
@@ -1,4 +1,4 @@
-import { createSignal } from "solid-js";
+import { createSignal, createEffect } from "solid-js";
 import type { Component } from "solid-js";
 import { Button } from "~/components/ui/Button";
 import {
@@ -16,7 +16,12 @@ interface RootTokenFormProps {
 
 export const RootTokenForm: Component<RootTokenFormProps> = (props) => {
   const [showToken, setShowToken] = createSignal(false);
+  const [inputValue, setInputValue] = createSignal(props.initialToken ?? "");
   let inputRef: HTMLInputElement | undefined;
+
+  createEffect(() => {
+    setInputValue(props.initialToken ?? "");
+  });
 
   const handleSubmit = (e: Event) => {
     e.preventDefault();
@@ -37,7 +42,8 @@ export const RootTokenForm: Component<RootTokenFormProps> = (props) => {
               id="root-token-input"
               type={showToken() ? "text" : "password"}
               placeholder="Enter your root token to manage other tokens"
-              value={props.initialToken ?? ""}
+              value={inputValue()}
+              onInput={(e) => setInputValue(e.currentTarget.value)}
             />
             <button
               type="button"

--- a/frontend/src/pages/tokens/lib.ts
+++ b/frontend/src/pages/tokens/lib.ts
@@ -7,7 +7,7 @@ import {
 } from "~/lib/api";
 import { Token } from "~/lib/types";
 import { showToast } from "~/components/ui/Toast";
-import { rootToken } from "~/lib/state";
+import { rootToken, setRootToken } from "~/lib/state";
 
 export enum SortableColumns {
   TIMESTAMP,
@@ -49,11 +49,23 @@ export const [tokens, { mutate: mutateTokens, refetch: refetchTokens }] =
         });
         return fetchedTokens;
       } catch (e) {
-        showToast({
-          title: "Error",
-          description: `Failed to fetch tokens. \n${e}`,
-          variant: "destructive",
-        });
+        if (e instanceof Error && e.message.includes("Unauthorized")) {
+          setRootToken(null);
+          localStorage.removeItem("rootToken");
+
+          showToast({
+            title: "Authentication Failed",
+            description:
+              "Invalid or expired token. Please enter a valid root token.",
+            variant: "destructive",
+          });
+        } else {
+          showToast({
+            title: "Error",
+            description: `Failed to fetch tokens. ${e instanceof Error ? e.message : String(e)}`,
+            variant: "destructive",
+          });
+        }
         return [];
       }
     },


### PR DESCRIPTION
## Description

This pull request improves the authentication flow and user experience on the tokens management page. It adds better handling for unauthorized API responses, ensures the root token input is updated reactively, and improves the logic for displaying token content. The most important changes are grouped by authentication handling, UI/UX improvements, and state management:

**Authentication Handling:**

* The `request` function in `api.ts` now throws a specific "Unauthorized" error when a 401 or 403 response is received, making it easier to handle authentication failures downstream.
* In `tokens/lib.ts`, when an "Unauthorized" error is caught during token fetching, the root token is cleared, removed from local storage, and a descriptive toast notification is shown to the user.

**UI/UX Improvements:**

* The tokens page now only shows token management content if a valid root token is present, tokens are done loading, and there are tokens to display, preventing UI glitches when tokens are missing or loading. 
* The root token input field in `RootTokenForm.tsx` is now controlled by a signal that updates whenever the initial token prop changes, ensuring the input stays in sync with the app state. 

**State Management:**

* The `setRootToken` function is now imported and used in `tokens/lib.ts` to clear the root token on authentication failure.

These changes collectively improve error handling, user feedback, and the reliability of the token management workflow.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have read the [**Contributing Guidelines**](./CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.